### PR TITLE
Feat: 최근 검색어 기능 구현 (낙관적 업데이트 미적용)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,10 +9,12 @@
       "version": "0.1.0",
       "dependencies": {
         "@stomp/stompjs": "^7.0.0",
+        "@types/lodash": "^4.14.202",
         "@types/stompjs": "^2.3.9",
         "@typescript-eslint/eslint-plugin": "^6.19.1",
         "axios": "^1.6.5",
         "http-proxy-middleware": "^2.0.6",
+        "lodash.debounce": "^4.0.8",
         "next": "^14.1.0",
         "react": "^18",
         "react-dom": "^18",
@@ -25,6 +27,7 @@
         "ws": "^8.16.0"
       },
       "devDependencies": {
+        "@types/lodash.debounce": "^4.0.9",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -746,6 +749,20 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/lodash": {
+      "version": "4.14.202",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.202.tgz",
+      "integrity": "sha512-OvlIYQK9tNneDlS0VN54LLd5uiPCBOp7gS5Z0f1mjoJYBrtStzgmJBxONW3U6OZqdtNzZPmn9BS/7WI7BFFcFQ=="
+    },
+    "node_modules/@types/lodash.debounce": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.9.tgz",
+      "integrity": "sha512-Ma5JcgTREwpLRwMM+XwBR7DaWe96nC38uCBDFKZWbNKD+osjVzdpnUSwBcqCptrp16sSOLBAUb50Car5I0TCsQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/lodash": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.11.3",
@@ -4862,6 +4879,11 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow=="
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -13,10 +13,12 @@
   },
   "dependencies": {
     "@stomp/stompjs": "^7.0.0",
+    "@types/lodash": "^4.14.202",
     "@types/stompjs": "^2.3.9",
     "@typescript-eslint/eslint-plugin": "^6.19.1",
     "axios": "^1.6.5",
     "http-proxy-middleware": "^2.0.6",
+    "lodash.debounce": "^4.0.8",
     "next": "^14.1.0",
     "react": "^18",
     "react-dom": "^18",
@@ -29,6 +31,7 @@
     "ws": "^8.16.0"
   },
   "devDependencies": {
+    "@types/lodash.debounce": "^4.0.9",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/src/components/Search.tsx
+++ b/src/components/Search.tsx
@@ -1,32 +1,40 @@
 import { useState } from "react";
-// import LocationPin from "../../public/svg/LocationPin";
+import debounce from 'lodash.debounce';
 import TriangleDown from "../../public/svg/TriangleDown";
 import { useRecoilState } from "recoil";
 import { searchState } from "@/stores/searchOptionState";
 import { menuState } from "@/stores/NavMenuState";
 
+import { recentKeywordSelector } from "@/stores/recentKeywordState";
+
 const Search = () => {
     const [ openOption, setOpenOption ] = useState(false);
     const [ selectOption, setSelectOption ] = useRecoilState(searchState);
-    const [ navMenuState, setNavMenuState ] = useRecoilState(menuState)
-//w-[430px]
-    // console.log(selectOption);
+    const [ navMenuState, setNavMenuState ] = useRecoilState(menuState);
+    const [ , setRecentKeyword ] = useRecoilState(recentKeywordSelector);
+    const [ inputText, setInputText ] = useState(""); 
 
     const handleOpen = (  ) => {
         setOpenOption(!openOption)
-    }
-
-    const handleKeyDown = (event: React.KeyboardEvent<HTMLInputElement>) => {
-
+    };
+    const handleKeyDown = debounce((event: React.KeyboardEvent<HTMLInputElement>) => {
         //메인 홈에서 검색하는 경우 
         if(event.key === "Enter" && navMenuState[0].onOff === false) {
             event.preventDefault();
             const target = event.target as HTMLInputElement;
+            const keyword = target.value.trim(); // 앞뒤 공백 제거 
             setSelectOption((prev) => ({
                 ...prev,
-                keyword: target.value
-            }))
-        } 
+                keyword: keyword
+            }));
+
+            //setRecentKeyword((prev) => ([ ...prev, target.value]));
+            setRecentKeyword((prev) => {
+                const update =  [...prev, target.value];
+                return update;         
+            });
+            setInputText("");
+        }; 
 
         //모달창에서 검색하는 경우 
         if(event.key === "Enter" && navMenuState[0].onOff === true){
@@ -36,12 +44,17 @@ const Search = () => {
                 ...prev,
                 keyword: target.value
             }));
-
+            setRecentKeyword((prev) => {
+                const update =  [...prev, target.value];
+                return update;         
+            });
+            setInputText("");
             const newMenuState = [{menu: "search", onOff: false}, {menu: "alarm", onOff: false}]
 
             setNavMenuState(newMenuState);
-        }
-    }
+        };
+    }, 500);
+    
 
     const handleOption = ( option: string ) => {
         setSelectOption((prev) => ({
@@ -49,7 +62,8 @@ const Search = () => {
             option: option
         }) );
         setOpenOption(false);
-    }
+    };
+
 
     return(
         <div className="w-full absolute ">
@@ -60,10 +74,11 @@ const Search = () => {
                     <TriangleDown width={"13px"} height={"15px"}/>
                 </button>
                 <input 
+                    value={inputText}
                     className="font-light w-full px-2 outline-none text-xs" 
                     placeholder="찾으시는 상품명, 카테고리를 입력하세요."
-                    // onChange={handleSearch}
-                    onKeyDown={(e) => handleKeyDown(e)}
+                    onChange={(e) => {setInputText(e.target.value)}}
+                    onKeyDown={(e) => { handleKeyDown(e)}}
                     ></input>
             </div>
             { openOption && (

--- a/src/components/navModal/RecentSearchItem.tsx
+++ b/src/components/navModal/RecentSearchItem.tsx
@@ -1,12 +1,16 @@
-import Close from "../../../public/svg/Close";
+// import Close from "../../../public/svg/Close";
 import SearchIcon from "../../../public/svg/SearchIcon";
 
-const RecentSearchItem = () => {
+type RecentKeywordTypes = {
+    keyword: string;
+}
+
+const RecentSearchItem = ({keyword}: RecentKeywordTypes) => {
     return(
-        <div className="flex flex-row justify-between items-center">
+        <div className="flex flex-row justify-between items-center my-3 text-sm">
             <SearchIcon width={"20px"} height={"20px"} />
-            <div className="font-normal flex-1 mx-3">신발230</div>
-            <Close width={"20px"} height={"20px"} />
+            <div className="font-light flex-1 mx-3">{keyword}</div>
+            {/* <Close width={"20px"} height={"20px"} /> */}
         </div>
     )
 }

--- a/src/components/navModal/SearchModal.tsx
+++ b/src/components/navModal/SearchModal.tsx
@@ -1,8 +1,19 @@
-
+import { useRecoilValue } from "recoil";
 import Search from "../Search";
 import RecentSearchItem from "./RecentSearchItem";
+import { recentKeywordState } from "@/stores/recentKeywordState";
+import LocalStorage from "@/util/localstorage";
+
 
 const SearchModal = () => {
+    const recentKeyword = useRecoilValue(recentKeywordState);
+
+    //낙관적 업데이트 적용.. 
+    const handleDeleteAll = (e:any) => {
+        e.preventDefault();
+        LocalStorage.removeItem("recentKeyword");
+    }
+
 
     return(
         <div className="absolute top-0 left-52 w-[371px] border-r border-LINE_BORDER whitespace-nowrap bg-white shadow-md z-50 py-10 min-h-screen">
@@ -12,11 +23,13 @@ const SearchModal = () => {
                 <div className="mt-5 border-t border-LINE_BORDER px-5">
                     <div className="flex flex-row justify-between font-semibold pt-5 pb-5">
                         <div className="text-lg">최근 검색 항목</div>
-                        <button className="text-MAIN_COLOR text-xs font-normal">모두지우기</button>
+                        <button className="text-MAIN_COLOR text-xs font-normal" onClick={(e) => handleDeleteAll(e)}>모두지우기</button>
                     </div>
-                    <div className="px-3">
-                        <RecentSearchItem />
-
+                    <div className="px-3 flex flex-col-reverse">
+                        {recentKeyword && recentKeyword.length > 0 && 
+                            recentKeyword.map((keyword, idx) => (
+                                <RecentSearchItem key={idx} keyword={keyword} />
+                            ))}
                     </div>
                 </div>
             </div>

--- a/src/stores/recentKeywordState.ts
+++ b/src/stores/recentKeywordState.ts
@@ -1,0 +1,24 @@
+import LocalStorage from "@/util/localstorage";
+import { atom, selector } from "recoil";
+
+const localKeyworad = LocalStorage.getItem("recentKeyword") ?  JSON.parse(LocalStorage.getItem("recentKeyword")!) : [];
+export const recentKeywordState = atom<string[]>({
+    key: "recentKeywordState",
+    default: localKeyworad
+});
+
+export const recentKeywordSelector = selector<string[]>({
+    key: "recentKeywordSelector",
+    get: ({get}) => {
+        const state = get(recentKeywordState);
+        return state;
+    },
+    set: ({set}, newValue) => {
+        if(Array.isArray(newValue)){
+            console.log("new ", newValue)
+            const newState = [...newValue].slice(-3);
+            set(recentKeywordState, newState);
+            LocalStorage.setItem("recentKeyword", JSON.stringify(newState))
+        };
+    }
+})


### PR DESCRIPTION
# 개요 
Feat: 최근 검색어 기능 구현 (낙관적 업데이트 미적용)

## 작업 사항 
- Recoil 활용하여 배열로 LocalStorage에 최근 검색어 저장 
- 중복 입력 방지 위해 Debounce 적용 

## 추가 리팩토링 예정 사항 
- 최근 검색어 모두 제거 시 낙관적 업데이트 미 적용으로 확인 필요 
  router.refresh는 CSR에서만 작용 
- 

<img width="351" alt="스크린샷 2024-02-16 오후 3 49 33" src="https://github.com/farmingsoon/FE/assets/110151638/142c4b3e-2527-4aeb-8f36-2b1e7f17e6ac">
