### PR TITLE
Feat: 채팅 페이지 로그인 상태만 이용 가능 하도록 설정

### DIFF
--- a/src/app/chat/[id]/page.tsx
+++ b/src/app/chat/[id]/page.tsx
@@ -46,6 +46,7 @@ export default function Chat() {
   const [messages, setMessages] = useState<message[]>([]);
   const [currentMessage, setCurrentMessage] = useState("");
   const userId = Number(LocalStorage.getItem("memberId"));
+  const isLogin = LocalStorage.getItem("loginState");
 
   const connect = () => {
     console.log("connect함수", chatSocket.current);
@@ -203,16 +204,22 @@ export default function Chat() {
   };
 
   useEffect(() => {
-    getList();
-    getHistoryChat();
-    getChatRoomInfo();
 
+    if(isLogin === "true"){
+      getList();
+      getHistoryChat();
+      getChatRoomInfo();
+    }
+
+    setOpenTokenModal({ tokenExpired: true })
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [params.id]);
 
   useEffect(() => {
     // console.log("새로고침", chatSocket);
-    connect();
+    if(isLogin === "true"){
+      connect();
+    }
 
     return () => {
       disconnect();

--- a/src/stores/loginState.ts
+++ b/src/stores/loginState.ts
@@ -11,7 +11,7 @@ interface loginAtomTypes {
 export const loginState = atom<loginAtomTypes>({
     key: "loginState",
     default : {
-        isLogin: LocalStorage.getItem("accessToken") === "true" ? true : false,
+        isLogin: LocalStorage.getItem("loginState") === "true" ? true : false,
         ACCESS_TOKEN: "",
         REFRESH_TOKEN: "",
         memberId: 0,


### PR DESCRIPTION
Feat: 채팅 페이지 로그인 상태만 이용 가능 하도록 설정

- LocalStorage의 로그인 상태 값을 기준으로 채팅 페이지 입장 시 false면 로그인 시도 후 하도록 설정 
- Navbar의 메뉴 바 상태도 로그인 상태에 따라 변경 