### PR TITLE
Feat: 채팅방 페이지에서는 모달 알림 중지 설정 + 로그인 후 replace 로 페이지 이동

### DIFF
--- a/src/app/chat/page.tsx
+++ b/src/app/chat/page.tsx
@@ -78,8 +78,7 @@ export default function Chat() {
   };
 
   useEffect(() => {
-    getList();
-    
+    getList(); 
   // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
 

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -68,7 +68,7 @@ export default function Login() {
                 LocalStorage.setItem("userName", userName);
                 LocalStorage.setItem("userProfileImg", profile);
 
-                router.push("/")
+                router.replace("/")
             }
 
 

--- a/src/components/sse/SSEcontrol.tsx
+++ b/src/components/sse/SSEcontrol.tsx
@@ -22,7 +22,9 @@ const SSEcontrol = () => {
 
 
     useEffect(() => {
-        console.log(" ==== SSE ==== ")
+        const pageLocation = window.location.pathname;
+        console.log(pageLocation)
+
 
         const connectSSE = () => {
             eventSource.current = new EventSourcePolyfill(`${BASE_URL}/api/notifications/subscribe`, {
@@ -48,7 +50,13 @@ const SSEcontrol = () => {
                 const customEvent = event as MessageEvent;
                 console.log(customEvent.data);
                 setGotMessage(true);  // 메뉴 바 핑
-                setShowNotification(true);  //상단 알림모달
+                //상단 알림모달
+                if(pageLocation.includes("chat")){
+                    console.log("채팅방 페이지 열려있음")
+                    setShowNotification(false);  
+                } else {
+                    setShowNotification(true);  
+                }
 
                 // clearTimeout을 호출할 때 useRef를 사용합니다.
                 if (notificationTimeoutId.current) {
@@ -67,7 +75,12 @@ const SSEcontrol = () => {
                 const customEvent = event as MessageEvent;
                 console.log(customEvent.data);
                 setGotChatMessage(true);  // 메뉴 바 핑
-                setShowNotification(true);  //상단 알림모달
+                if(pageLocation.includes("chat")){
+                    console.log("채팅방 페이지 열려있음")
+                    setShowNotification(false);  
+                } else {
+                    setShowNotification(true);  
+                }
 
                 // clearTimeout을 호출할 때 useRef를 사용합니다.
                 if (notificationTimeoutId.current) {


### PR DESCRIPTION
### Feat: 채팅방 페이지에서는 모달 알림 중지 설정 + 로그인 후 replace 로 페이지 이동
- window.location.pathname으로 현재 페이지 위치 확인 
    * sseControl에서 채팅방 페이지 일 경우는 모달 알림 중지 설정 
- 로그인 후 메인 홈페이지로 이동 함수 변경 
    * router.push -> router.replace
    * history stack제거